### PR TITLE
Pb-554-environmental-settings-setup

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,7 +1,7 @@
-DEBUG=True
 DB_USER=postgres
 DB_NAME=postgres
 DB_PW=postgres
 DB_PORT=5432
 DB_HOST=localhost
 DB_NAME_TEST=postgres
+DJANGO_SETTINGS_MODULE=config.settings_dev

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ setup: $(SETTINGS_TIMESTAMP) setup-s3-and-db setup-logs ## Setup the project by 
 	# Create virtual env with all packages for development
 	pipenv install --dev
 	pipenv shell
+	cp .env.default .env
 
 
 .PHONY: format

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,9 @@ yapf = "*"
 pylint = "*"
 pylint-django = "*"
 ipdb = "*"
+isort = "*"
+django-extensions = "~=3.2"
+django_debug_toolbar= "~=4.2"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32f08035fa805a6a65290c82c057ddc0f3b4a8295d0ed268d28ba806f7fd2e0a"
+            "sha256": "9318e66cebea1355ce315c3e779a45a8f44c25f9d900d2dbba57ccacfd85bc5f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -249,6 +249,14 @@
         }
     },
     "develop": {
+        "asgiref": {
+            "hashes": [
+                "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47",
+                "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.8.1"
+        },
         "astroid": {
             "hashes": [
                 "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94",
@@ -279,6 +287,33 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==0.3.8"
+        },
+        "django": {
+            "hashes": [
+                "sha256:8363ac062bb4ef7c3f12d078f6fa5d154031d129a15170a1066412af49d30905",
+                "sha256:ff1b61005004e476e0aeea47c7f79b85864c70124030e95146315396f1e7951f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==5.0.6"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:5d7afb2ea5f8730241e5b0735396e16cd1fd8c6b53a2f3e1e30bbab9abb23728",
+                "sha256:9204050fcb1e4f74216c5b024bc76081451926a6303993d6c513f5e142675927"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.4.2"
+        },
+        "django-extensions": {
+            "hashes": [
+                "sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a",
+                "sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==3.2.3"
         },
         "exceptiongroup": {
             "hashes": [
@@ -326,6 +361,7 @@
                 "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
+            "index": "pypi",
             "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
@@ -441,6 +477,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
+        "sqlparse": {
+            "hashes": [
+                "sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93",
+                "sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.5.0"
+        },
         "stack-data": {
             "hashes": [
                 "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9",
@@ -453,7 +497,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "tomlkit": {

--- a/app/config/settings_base.py
+++ b/app/config/settings_base.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
-import os
 import environ
 
 env = environ.Env()
@@ -27,7 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-6-72r#zx=sv6v@-4k@uf1gv32me@%yr*oqa*fu8&5l&a!ws)5#'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', False)
+DEBUG = False
 
 ALLOWED_HOSTS = []
 
@@ -94,20 +93,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME':
-        'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
     {
-        'NAME':
-        'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
     {
-        'NAME':
-        'django.contrib.auth.password_validation.CommonPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
     {
-        'NAME':
-        'django.contrib.auth.password_validation.NumericPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
 

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -6,3 +6,10 @@ env = environ.Env()
 
 DEBUG = env.bool('DEBUG', True)
 
+if DEBUG:
+    INSTALLED_APPS += ['django_extensions', 'debug_toolbar']
+
+if DEBUG:
+    MIDDLEWARE = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + MIDDLEWARE

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -1,0 +1,8 @@
+import environ
+
+from .settings_base import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+env = environ.Env()
+
+DEBUG = env.bool('DEBUG', True)
+

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -1,0 +1,3 @@
+from .settings_base import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+DEBUG = False

--- a/app/manage.py
+++ b/app/manage.py
@@ -6,14 +6,16 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    # default to the prod settings. Can be overwritten with .env
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings_prod')
     try:
-        from django.core.management import execute_from_command_line
+        from django.core.management import execute_from_command_line  # pylint: disable=import-outside-toplevel
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?") from exc
+            "forget to activate a virtual environment?"
+        ) from exc
     execute_from_command_line(sys.argv)
 
 


### PR DESCRIPTION
I intentionally deviated here a bit from the way service-stac is doing it. This is the way that I'm used to, and it seems simpler, as it allows setting the conf via .env.

The .env file is loaded via pipenv. Like this, we can omit all the complicated code in the `manage.py` file. 