### PR TITLE
PB-903 Configure pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,11 +148,6 @@ start-local-db: ## Run the local db as docker container
 .PHONY: test
 test: ## Run tests locally
 	$(TEST)
-.PHONY: test-debug
-test-debug: ## Run tests locally as soon as debugger is attached
-	# Collect static first to avoid warning in the test
-	$(PYTHON) $(DJANGO_MANAGER) collectstatic --noinput
-	$(PYTHON) $(DJANGO_MANAGER_DEBUG) test --verbosity=2 $(CI_TEST_OPT) $(TEST_DIR) $(APP_SRC_DIR)
 
 .PHONY: help
 help: ## Display this help

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ DJANGO_MANAGER_DEBUG := -m debugpy --listen localhost:5678 --wait-for-client $(C
 # Commands
 PIPENV_RUN := pipenv run
 PYTHON := $(PIPENV_RUN) python3
+TEST := $(PIPENV_RUN) pytest
 YAPF := $(PIPENV_RUN) yapf
 ISORT := $(PIPENV_RUN) isort
 PYLINT := $(PIPENV_RUN) pylint
@@ -146,10 +147,7 @@ start-local-db: ## Run the local db as docker container
 
 .PHONY: test
 test: ## Run tests locally
-	# Collect static first to avoid warning in the test
-	# $(PYTHON) $(DJANGO_MANAGER) collectstatic --noinput
-	$(PYTHON) $(DJANGO_MANAGER) test --verbosity=2 --parallel 20 $(CI_TEST_OPT) $(TEST_DIR) $(APP_SRC_DIR)
-
+	$(TEST)
 .PHONY: test-debug
 test-debug: ## Run tests locally as soon as debugger is attached
 	# Collect static first to avoid warning in the test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 - [Local Development](#local-development-1)
   - [vs code Integration](#vs-code-integration)
     - [Debug from vs code](#debug-from-vs-code)
-    - [Attach debugger to the tests](#attach-debugger-to-the-tests)
     - [Run tests from within vs code](#run-tests-from-within-vs-code)
 - [Type Checking](#type-checking)
   - [Mypy](#mypy)
@@ -96,10 +95,6 @@ Alternatively, create the file via menu "Run" > "Add Configuration" by choosing
 Now you can start the server with `make serve-debug`.
 The bootup will wait with the execution until the debugger is attached, which can most easily done by hitting F5.
 
-#### Attach debugger to the tests
-
-The same process described above can be used to debug tests. Simply run `make test-debug`, they will
-then wait until the debugger is attached.
 
 #### Run tests from within vs code
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ To do this you need to have the following settings either in
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.testing.debugPort": 5678
 ```
 
 You can also create this file interactively via menu "Python: Configure Tests"

--- a/app/config/settings_base.py
+++ b/app/config/settings_base.py
@@ -123,7 +123,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = 'static/'
-STATIC_ROOT = BASE_DIR / 'var' / 'www' / 'service_control' / 'static_files'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE= app.config.settings_test
-
+DJANGO_SETTINGS_MODULE= app.config.settings_dev
+pythonpath = app
 python_files = test_*.py


### PR DESCRIPTION
Summary of changes:
1. Make it possible to run the test just by typing `pytest` in the console (or, as before, `make test`). We already had Python module `django-pytest` installed but it was not used; we had to go via `manage.py test` to run tests. Pytest is faster and its output is easier to read.
2. Remove Make target `test-debug`. I see no point in this, it was copied from `service-stac`. Both the pytest CLI and the IDE can handle debugging without this.