### PR TITLE
PB-903 Drop the explicit schema invocations

### DIFF
--- a/app/distributions/tests/test_api.py
+++ b/app/distributions/tests/test_api.py
@@ -2,12 +2,10 @@ import datetime
 from unittest import mock
 
 from distributions.api import attribution_to_response
-from distributions.api import dataset_to_response
 from distributions.api import router
 from distributions.models import Attribution
 from distributions.models import Dataset
 from distributions.schemas import AttributionSchema
-from distributions.schemas import DatasetSchema
 from ninja.testing import TestClient
 from provider.models import Provider
 from schemas import TranslationsSchema
@@ -513,20 +511,6 @@ class ApiTestCase(TestCase):
                 },
             ]
         }
-
-    def test_dataset_to_response_returns_response_as_expected(self):
-        dataset = Dataset.objects.last()
-
-        actual = dataset_to_response(dataset)
-
-        assert actual == DatasetSchema(
-            id=str(dataset.id),
-            slug="ch.bafu.neophyten-haargurke",
-            created=self.time_created.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            updated=self.time_created.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            provider_id=str(Provider.objects.last().id),
-            attribution_id=str(Attribution.objects.last().id),
-        )
 
     def test_get_dataset_returns_specified_dataset(self):
         dataset_id = Dataset.objects.last().id

--- a/app/provider/api.py
+++ b/app/provider/api.py
@@ -9,34 +9,33 @@ from django.shortcuts import get_object_or_404
 from .models import Provider
 from .schemas import ProviderListSchema
 from .schemas import ProviderSchema
-from .schemas import TranslationsSchema
 
 router = Router()
 
 
-def provider_to_response(model: Provider, lang: LanguageCode) -> ProviderSchema:
+def provider_to_response(model: Provider, lang: LanguageCode) -> dict:
     """
-    Transforms the given model using the given language into a response object.
+    Transforms the given model using the given language into the response structure.
     """
-    response = ProviderSchema(
-        id=str(model.id),
-        name=get_translation(model, "name", lang),
-        name_translations=TranslationsSchema(
-            de=model.name_de,
-            fr=model.name_fr,
-            en=model.name_en,
-            it=model.name_it,
-            rm=model.name_rm,
-        ),
-        acronym=get_translation(model, "acronym", lang),
-        acronym_translations=TranslationsSchema(
-            de=model.acronym_de,
-            fr=model.acronym_fr,
-            en=model.acronym_en,
-            it=model.acronym_it,
-            rm=model.acronym_rm,
-        )
-    )
+    response = {
+        "id": str(model.id),
+        "name": get_translation(model, "name", lang),
+        "name_translations": {
+            "de": model.name_de,
+            "fr": model.name_fr,
+            "en": model.name_en,
+            "it": model.name_it,
+            "rm": model.name_rm,
+        },
+        "acronym": get_translation(model, "acronym", lang),
+        "acronym_translations": {
+            "de": model.acronym_de,
+            "fr": model.acronym_fr,
+            "en": model.acronym_en,
+            "it": model.acronym_it,
+            "rm": model.acronym_rm,
+        }
+    }
     return response
 
 
@@ -104,4 +103,4 @@ def providers(request: HttpRequest, lang: LanguageCode | None = None):
     lang_to_use = get_language(lang, request.headers)
 
     schemas = [provider_to_response(model, lang_to_use) for model in models]
-    return ProviderListSchema(items=schemas)
+    return {"items": schemas}

--- a/app/provider/tests/test_api.py
+++ b/app/provider/tests/test_api.py
@@ -2,8 +2,6 @@ from ninja.testing import TestClient
 from provider.api import provider_to_response
 from provider.api import router
 from provider.models import Provider
-from provider.schemas import ProviderSchema
-from schemas import TranslationsSchema
 
 from django.test import TestCase
 
@@ -31,25 +29,25 @@ class ApiTestCase(TestCase):
 
         actual = provider_to_response(model, lang="de")
 
-        expected = ProviderSchema(
-            id=str(model.id),
-            name="Bundesamt für Umwelt",
-            name_translations=TranslationsSchema(
-                de="Bundesamt für Umwelt",
-                fr="Office fédéral de l'environnement",
-                en="Federal Office for the Environment",
-                it="Ufficio federale dell'ambiente",
-                rm="Uffizi federal per l'ambient",
-            ),
-            acronym="BAFU",
-            acronym_translations=TranslationsSchema(
-                de="BAFU",
-                fr="OFEV",
-                en="FOEN",
-                it="UFAM",
-                rm="UFAM",
-            )
-        )
+        expected = {
+            "id": str(model.id),
+            "name": "Bundesamt für Umwelt",
+            "name_translations": {
+                "de": "Bundesamt für Umwelt",
+                "fr": "Office fédéral de l'environnement",
+                "en": "Federal Office for the Environment",
+                "it": "Ufficio federale dell'ambiente",
+                "rm": "Uffizi federal per l'ambient",
+            },
+            "acronym": "BAFU",
+            "acronym_translations": {
+                "de": "BAFU",
+                "fr": "OFEV",
+                "en": "FOEN",
+                "it": "UFAM",
+                "rm": "UFAM",
+            }
+        }
 
         assert actual == expected
 
@@ -63,25 +61,25 @@ class ApiTestCase(TestCase):
 
         actual = provider_to_response(provider, lang="it")
 
-        expected = ProviderSchema(
-            id=str(provider.id),
-            name="Federal Office for the Environment",
-            name_translations=TranslationsSchema(
-                de="Bundesamt für Umwelt",
-                fr="Office fédéral de l'environnement",
-                en="Federal Office for the Environment",
-                it=None,
-                rm=None,
-            ),
-            acronym="FOEN",
-            acronym_translations=TranslationsSchema(
-                de="BAFU",
-                fr="OFEV",
-                en="FOEN",
-                it=None,
-                rm=None,
-            )
-        )
+        expected = {
+            "id": str(provider.id),
+            "name": "Federal Office for the Environment",
+            "name_translations": {
+                "de": "Bundesamt für Umwelt",
+                "fr": "Office fédéral de l'environnement",
+                "en": "Federal Office for the Environment",
+                "it": None,
+                "rm": None,
+            },
+            "acronym": "FOEN",
+            "acronym_translations": {
+                "de": "BAFU",
+                "fr": "OFEV",
+                "en": "FOEN",
+                "it": None,
+                "rm": None,
+            }
+        }
 
         assert actual == expected
 


### PR DESCRIPTION
According to the docs, it isn't necessary to invoke the Schemas by ourselves. The endpoint functions return the data as lists, querysets or dicts and the Framework handles the conversion to the schema. I don't see an immediate drawback to our version, but I'm also not so comfortable to deviate from the standard way proposed by the docs.

From the [docs](https://django-ninja.dev/guides/response/), NinjaAPI seems to do quite some tasks with the returned data itself and in my opinion we shouldn't be doing this ourselves unless we have a good reason to.
Also, there might be performance optimizations being done by NinjaAPI (consider especially when returning entire querysets)