### PR TITLE
PB-1045 Add POST endpoint to create User

### DIFF
--- a/app/access/api.py
+++ b/app/access/api.py
@@ -1,8 +1,6 @@
 from ninja import Router
 from provider.models import Provider
-from utils.exceptions import validation_error_to_http_error
 
-from django.core.exceptions import ValidationError
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 
@@ -60,15 +58,11 @@ def create_user(request: HttpRequest, user_in: UserSchema) -> UserSchema:
     """
     provider = get_object_or_404(Provider, id=user_in.provider_id)
 
-    try:
-        user_out = User.objects.create(
-            username=user_in.username,
-            first_name=user_in.first_name,
-            last_name=user_in.last_name,
-            email=user_in.email,
-            provider=provider
-        )
-    except ValidationError as error:
-        raise validation_error_to_http_error(error) from error
-
+    user_out = User.objects.create(
+        username=user_in.username,
+        first_name=user_in.first_name,
+        last_name=user_in.last_name,
+        email=user_in.email,
+        provider=provider
+    )
     return user_to_response(user_out)

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -47,12 +47,13 @@ def users(request: HttpRequest) -> dict[str, list[UserSchema]]:
     return {"items": responses}
 
 
-@router.post("users", response=UserSchema)
+@router.post("users", response={201: UserSchema})
 def create_user(request: HttpRequest, user_in: UserSchema) -> UserSchema:
     """Create the given user and return it.
 
     Return HTTP status code
 
+        - 201 (Created) if the User was created as expected
         - 404 (Not Found) if there is no provider with the given provider ID
         - 409 (Conflict) if there is already a record with the same username
         - 422 (Unprocessable Content) if there is any other invalid value
@@ -69,4 +70,5 @@ def create_user(request: HttpRequest, user_in: UserSchema) -> UserSchema:
         )
     except ValidationError as error:
         raise validation_error_to_http_error(error) from error
+
     return user_to_response(user_out)

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -1,5 +1,8 @@
 from ninja import Router
+from provider.models import Provider
+from utils.exceptions import validation_error_to_http_error
 
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 
@@ -42,3 +45,28 @@ def users(request: HttpRequest) -> dict[str, list[UserSchema]]:
     models = User.objects.all()
     responses = [user_to_response(model) for model in models]
     return {"items": responses}
+
+
+@router.post("users", response=UserSchema)
+def create_user(request: HttpRequest, user_in: UserSchema) -> UserSchema:
+    """Create the given user and return it.
+
+    Return HTTP status code
+
+        - 404 (Not Found) if there is no provider with the given provider ID
+        - 409 (Conflict) if there is already a record with the same username
+        - 422 (Unprocessable Content) if there is any other invalid value
+    """
+    provider = get_object_or_404(Provider, id=user_in.provider_id)
+
+    try:
+        user_out = User.objects.create(
+            username=user_in.username,
+            first_name=user_in.first_name,
+            last_name=user_in.last_name,
+            email=user_in.email,
+            provider=provider
+        )
+    except ValidationError as error:
+        raise validation_error_to_http_error(error) from error
+    return user_to_response(user_out)

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -136,6 +136,7 @@ class ApiTestCase(TestCase):
         response = self.client.post("users", json=payload)
 
         assert response.status_code == 404
+        assert response.data == {"detail": "Not Found: No Provider matches the given query."}
 
     def test_post_users_returns_422_if_email_format_invalid(self):
 

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -41,8 +41,7 @@ class ApiTestCase(TestCase):
 
     def test_get_user_returns_existing_user(self):
 
-        client = TestClient(router)
-        response = client.get("users/dude")
+        response = self.client.get("users/dude")
 
         assert response.status_code == 200
         assert response.data == {
@@ -55,16 +54,14 @@ class ApiTestCase(TestCase):
 
     def test_get_user_returns_404_if_nonexisting(self):
 
-        client = TestClient(router)
-        response = client.get("users/nihilist")
+        response = self.client.get("users/nihilist")
 
         assert response.status_code == 404
         assert response.data == {"detail": "Not Found"}
 
     def test_get_users_returns_single_user(self):
 
-        client = TestClient(router)
-        response = client.get("users")
+        response = self.client.get("users")
 
         assert response.status_code == 200
         assert response.data == {
@@ -88,8 +85,7 @@ class ApiTestCase(TestCase):
         }
         User.objects.create(**model_fields)
 
-        client = TestClient(router)
-        response = client.get("users")
+        response = self.client.get("users")
 
         assert response.status_code == 200
         assert response.data == {

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -123,7 +123,7 @@ class ApiTestCase(TestCase):
 
         response = self.client.post("users", json=payload)
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.data == payload
 
     def test_post_users_returns_404_if_provider_id_does_not_exist(self):

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -153,7 +153,7 @@ class ApiTestCase(TestCase):
         assert response.status_code == 422
         assert response.data == {'detail': "['Enter a valid email address.']"}
 
-    def test_post_users_returns_422_if_user_exists_already(self):
+    def test_post_users_returns_409_if_user_exists_already(self):
 
         payload = {
             "username": "dude",
@@ -168,7 +168,7 @@ class ApiTestCase(TestCase):
         assert response.status_code == 409
         assert response.data == {'detail': "['User with this User name already exists.']"}
 
-    def test_post_users_returns_422_and_reports_all_errors_if_multiple_things_amiss(self):
+    def test_post_users_returns_409_and_reports_all_errors_if_multiple_things_amiss(self):
 
         invalid_email = "donny_at_bowling_dot_com"
         payload = {

--- a/app/config/api.py
+++ b/app/config/api.py
@@ -2,14 +2,35 @@ from access.api import router as access_router
 from distributions.api import router as distributions_router
 from ninja import NinjaAPI
 from provider.api import router as provider_router
+from utils.exceptions import contains_error_code
+from utils.exceptions import extract_error_messages
 
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest
+from django.http import HttpResponse
 
 api = NinjaAPI()
 
 api.add_router("", provider_router)
 api.add_router("", distributions_router)
 api.add_router("", access_router)
+
+
+@api.exception_handler(ValidationError)
+def validation_error(request: HttpRequest, exception: ValidationError) -> HttpResponse:
+    conflict_http_code = 409
+    if contains_error_code(exception, conflict_http_code):
+        status = conflict_http_code
+    else:
+        status = 422
+
+    messages = extract_error_messages(exception)
+    return api.create_response(
+        request,
+        {"detail": messages},
+        status=status,
+    )
+
 
 root = NinjaAPI(urls_namespace="root")
 

--- a/app/config/api.py
+++ b/app/config/api.py
@@ -6,6 +6,7 @@ from utils.exceptions import contains_error_code
 from utils.exceptions import extract_error_messages
 
 from django.core.exceptions import ValidationError
+from django.http import Http404
 from django.http import HttpRequest
 from django.http import HttpResponse
 
@@ -30,6 +31,30 @@ def validation_error_to_response(request: HttpRequest, exception: ValidationErro
         request,
         {"detail": messages},
         status=status,
+    )
+
+
+@api.exception_handler(Http404)
+def http404_to_response(request: HttpRequest, exception: Http404) -> HttpResponse:
+    """Convert the given exception to a Not Found response with the actual exception message.
+
+    Without this, we would only see "Not found" in the response even if the
+    original exception message is more detailed like "No User matches the given query.".
+    """
+    return api.create_response(
+        request,
+        {"detail": str(exception)},
+        status=404,
+    )
+
+
+@api.exception_handler(Exception)
+def exception_to_response(request: HttpRequest, exception: Exception) -> HttpResponse:
+    """Convert the given exception to a generic internal server error."""
+    return api.create_response(
+        request,
+        {"detail": str(exception)},
+        status=500,
     )
 
 

--- a/app/config/api.py
+++ b/app/config/api.py
@@ -17,10 +17,11 @@ api.add_router("", access_router)
 
 
 @api.exception_handler(ValidationError)
-def validation_error(request: HttpRequest, exception: ValidationError) -> HttpResponse:
-    conflict_http_code = 409
-    if contains_error_code(exception, conflict_http_code):
-        status = conflict_http_code
+def validation_error_to_response(request: HttpRequest, exception: ValidationError) -> HttpResponse:
+    """Convert the given validation error  to a response with corresponding status."""
+    error_code_unique_constraint_violated = "unique"
+    if contains_error_code(exception, error_code_unique_constraint_violated):
+        status = 409
     else:
         status = 422
 

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -1,0 +1,26 @@
+from ninja.errors import HttpError
+
+from django.core.exceptions import ValidationError
+
+
+def validation_error_to_http_error(error: ValidationError) -> HttpError:
+    """Create a HttpError out of the relevant part of a Django ValidationError.
+
+    This assumes that the ValidationError has attribute error_dict set, as it
+    is done in model validation.
+
+    The returned HttpError has its HTTP status code set to
+
+        - 409 (Conflict) if there is an error indicating that a unique constraint is violated
+        - 422 (Unprocessable Content) if there are no unique constraint violations
+
+    The message in HttpError is the raw list of messages in the ValidationError, for example:
+
+        "['Enter a valid email address.', 'User with this User name already exists.']"
+    """
+    for errors_field in error.error_dict.values():
+        for error_inner in errors_field:
+            if error_inner.code == 'unique':
+                return HttpError(status_code=409, message=str(error.messages))
+
+    return HttpError(status_code=422, message=str(error.messages))

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -7,12 +7,17 @@ def contains_error_code(exception: ValidationError, code: str) -> bool:
         if exception.code == code:
             return True
 
+    # Iterating over the messages does not work here because the messages do not
+    # contain the error codes of the validation.
     if hasattr(exception, "error_dict"):
         for errors_field in exception.error_dict.values():
             for error in errors_field:
                 if error.code == code:
                     return True
-
+    elif hasattr(exception, "error_list"):
+        for error in exception.error_list:
+            if error.code == code:
+                return True
     return False
 
 

--- a/app/utils/tests/test_exceptions.py
+++ b/app/utils/tests/test_exceptions.py
@@ -1,65 +1,97 @@
-from utils.exceptions import validation_error_to_http_error
+from utils.exceptions import contains_error_code
+from utils.exceptions import extract_error_messages
 
 from django.core.exceptions import ValidationError
 
 
-def test_validation_error_to_http_error_returns_409_for_single_unique():
+def test_contains_error_code_returns_true_for_single_error_with_matching_code():
 
-    error = ValidationError({
-        'field1': [ValidationError(code="unique", message="my message")],
+    exception = ValidationError(message=None, code="code1")
+    assert contains_error_code(exception, "code1")
+
+
+def test_contains_error_code_returns_false_for_single_error_without_matching_code():
+
+    exception = ValidationError(message=None, code="code1")
+    assert not contains_error_code(exception, "code2")
+
+
+def test_contains_error_code_returns_true_for_error_dict_where_one_has_matching_code():
+
+    exception = ValidationError({
+        "field1": ValidationError(message=None, code="code1"),
+        "field2": ValidationError(message=None, code="code2"),
     })
-    actual = validation_error_to_http_error(error)
-    assert actual.status_code == 409
-    assert actual.message == "['my message']"
+    assert contains_error_code(exception, "code2")
 
 
-def test_validation_error_to_http_error_returns_422_for_single_invalid():
+def test_contains_error_code_returns_false_for_error_dict_without_matching_code():
 
-    error = ValidationError({
-        'field1': [ValidationError(code="invalid", message="my message")],
+    exception = ValidationError({
+        "field1": ValidationError(message=None, code="code1"),
+        "field2": ValidationError(message=None, code="code2"),
     })
-    actual = validation_error_to_http_error(error)
-    assert actual.status_code == 422
-    assert actual.message == "['my message']"
+    assert not contains_error_code(exception, "code3")
 
 
-def test_validation_error_to_http_error_returns_409_when_at_least_one_unique():
+def test_contains_error_code_returns_true_for_multiple_errors_per_field():
 
-    error = ValidationError(
-        message={
-            "field1": [ValidationError(code="unique", message="my message 1")],
-            "field2": [ValidationError(code="invalid", message="my message 2")],
-        },
-    )
-    actual = validation_error_to_http_error(error)
-    assert actual.status_code == 409
-    assert actual.message == "['my message 1', 'my message 2']"
-
-
-def test_validation_error_to_http_error_returns_409_even_when_unique_burried_deep():
-
-    error = ValidationError(
-        message={
-            "field1": [
-                ValidationError(code="invalid", message="my message 1.1"),
-                ValidationError(code="unique", message="my message 1.2"),
-            ],
-            "field2": [ValidationError(code="invalid", message="my message 2")],
-        },
-    )
-    actual = validation_error_to_http_error(error)
-    assert actual.status_code == 409
-    assert actual.message == "['my message 1.1', 'my message 1.2', 'my message 2']"
+    exception = ValidationError({
+        "field1": [
+            ValidationError(message=None, code="code1"),
+            ValidationError(message=None, code="code2")
+        ],
+        "field2": [ValidationError(message=None, code="code3")],
+    })
+    assert contains_error_code(exception, "code2")
 
 
-def test_validation_error_to_http_error_returns_422_when_no_unique():
+def test_contains_error_code_returns_false_for_multiple_errors_per_field_without_matching():
 
-    error = ValidationError(
-        message={
-            "field1": [ValidationError(code="whatever", message="my message 1")],
-            "field2": [ValidationError(code="invalid", message="my message 2")],
-        },
-    )
-    actual = validation_error_to_http_error(error)
-    assert actual.status_code == 422
-    assert actual.message == "['my message 1', 'my message 2']"
+    exception = ValidationError({
+        "field1": [
+            ValidationError(message=None, code="code1"),
+            ValidationError(message=None, code="code2")
+        ],
+        "field2": [ValidationError(message=None, code="code3")],
+    })
+    assert not contains_error_code(exception, "code4")
+
+
+def test_extract_error_messages_results_in_single_element_for_single_message():
+
+    exception = ValidationError(message="XXX")
+    assert extract_error_messages(exception) == ["XXX"]
+
+
+def test_extract_error_messages_results_in_empty_list_when_no_message():
+
+    exception = ValidationError(message=None)
+    assert not extract_error_messages(exception)
+
+
+def test_extract_error_messages_finds_all_messages_in_dict():
+
+    exception = ValidationError({
+        "field1": ValidationError(message="m1"),
+        "field2": ValidationError(message="m2"),
+    })
+    assert extract_error_messages(exception) == ["m1", "m2"]
+
+
+def test_extract_error_messages_skips_undefined_messages_in_dict():
+
+    exception = ValidationError({
+        "field1": ValidationError(message="m1"),
+        "field2": ValidationError(message=None),
+    })
+    assert extract_error_messages(exception) == ["m1"]
+
+
+def test_extract_error_messages_finds_all_messages_in_dict_with_list():
+
+    exception = ValidationError({
+        "field1": [ValidationError(message="m1"), ValidationError(message="m2")],
+        "field2": [ValidationError(message="m3")],
+    })
+    assert extract_error_messages(exception) == ["m1", "m2", "m3"]

--- a/app/utils/tests/test_exceptions.py
+++ b/app/utils/tests/test_exceptions.py
@@ -1,0 +1,65 @@
+from utils.exceptions import validation_error_to_http_error
+
+from django.core.exceptions import ValidationError
+
+
+def test_validation_error_to_http_error_returns_409_for_single_unique():
+
+    error = ValidationError({
+        'field1': [ValidationError(code="unique", message="my message")],
+    })
+    actual = validation_error_to_http_error(error)
+    assert actual.status_code == 409
+    assert actual.message == "['my message']"
+
+
+def test_validation_error_to_http_error_returns_422_for_single_invalid():
+
+    error = ValidationError({
+        'field1': [ValidationError(code="invalid", message="my message")],
+    })
+    actual = validation_error_to_http_error(error)
+    assert actual.status_code == 422
+    assert actual.message == "['my message']"
+
+
+def test_validation_error_to_http_error_returns_409_when_at_least_one_unique():
+
+    error = ValidationError(
+        message={
+            "field1": [ValidationError(code="unique", message="my message 1")],
+            "field2": [ValidationError(code="invalid", message="my message 2")],
+        },
+    )
+    actual = validation_error_to_http_error(error)
+    assert actual.status_code == 409
+    assert actual.message == "['my message 1', 'my message 2']"
+
+
+def test_validation_error_to_http_error_returns_409_even_when_unique_burried_deep():
+
+    error = ValidationError(
+        message={
+            "field1": [
+                ValidationError(code="invalid", message="my message 1.1"),
+                ValidationError(code="unique", message="my message 1.2"),
+            ],
+            "field2": [ValidationError(code="invalid", message="my message 2")],
+        },
+    )
+    actual = validation_error_to_http_error(error)
+    assert actual.status_code == 409
+    assert actual.message == "['my message 1.1', 'my message 1.2', 'my message 2']"
+
+
+def test_validation_error_to_http_error_returns_422_when_no_unique():
+
+    error = ValidationError(
+        message={
+            "field1": [ValidationError(code="whatever", message="my message 1")],
+            "field2": [ValidationError(code="invalid", message="my message 2")],
+        },
+    )
+    actual = validation_error_to_http_error(error)
+    assert actual.status_code == 422
+    assert actual.message == "['my message 1', 'my message 2']"

--- a/app/utils/tests/test_exceptions.py
+++ b/app/utils/tests/test_exceptions.py
@@ -58,6 +58,22 @@ def test_contains_error_code_returns_false_for_multiple_errors_per_field_without
     assert not contains_error_code(exception, "code4")
 
 
+def test_contains_error_code_returns_true_for_list_of_errors():
+
+    exception = ValidationError([
+        ValidationError(message=None, code="code1"), ValidationError(message=None, code="code2")
+    ])
+    assert contains_error_code(exception, "code2")
+
+
+def test_contains_error_code_returns_false_for_list_of_errors_without_matching():
+
+    exception = ValidationError([
+        ValidationError(message=None, code="code1"), ValidationError(message=None, code="code2")
+    ])
+    assert not contains_error_code(exception, "code3")
+
+
 def test_extract_error_messages_results_in_single_element_for_single_message():
 
     exception = ValidationError(message="XXX")


### PR DESCRIPTION
This is a follow-up of [the PR](https://github.com/geoadmin/service-control/pull/30) that added the User model and their corresponding GET endpoints.

Summary of changes:
1. Add a POST endpoint that lets you create a `User` through the REST API.
    :information_source: This returns the created user and HTTP status codes according to [the API specs](https://2zvidp4qyh.apidog.io/api-10771349):
        - `201` (Created) if the User was created as expected
        - `404` (Not Found) if there is no provider with the given provider ID
        - `409` (Conflict) if there is already a record with the same username
        - `422` (Unprocessable Content) if there is any other invalid value
2. Helper function to check if the `ValidationError` raised by the model validation contains a violation of the unique constraint on `User.username` (marked by `ValidationError.code == 'unique'`). I find that somewhat shaky, the `ValidationError` class [is super flexible](https://github.com/django/django/blob/df6013b2b4e93ed6d127c2f572e6de0ba46d1d6a/django/core/exceptions.py#L134). Yet I would like to avoid having too many `isinstance(...)` / `hasattribute(...)`. In the unit test for the API endpoint, I observed that model validation creates the `ValidationError` always in the same way (something like `ValidationError.error_dict == {"field1": [ValidationError(...), ValidationError(...)], "field2": [...]}`. So maybe it is good enough but open to better suggestions.
3. Minor refactoring in unit tests `test_api.py` to reuse `TestClient` instead of creating it again in each test.

Example response for a successful POST `api/users` (code 201):

```json
{
    "username": "donny",
    "first_name": "Theodore Donald",
    "last_name": "Kerabatsos",
    "email": "donny@bowling.com",
    "provider_id": 123
}
```

Example response for a payload with invalid email and a username that already exists (code 409):

```json
{
    "detail": "['Enter a valid email address.', 'User with this User name already exists.']"
}
```