### PR TITLE
Add bandit security checker

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude = tests

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ YAPF := $(PIPENV_RUN) yapf
 ISORT := $(PIPENV_RUN) isort
 PYLINT := $(PIPENV_RUN) pylint
 MYPY := $(PIPENV_RUN) mypy
+BANDIT := $(PIPENV_RUN) bandit
 
 # Find all python files that are not inside a hidden directory (directory starting with .)
 PYTHON_FILES := $(shell find $(APP_SRC_DIR) -type f -name "*.py" -print)
@@ -148,6 +149,10 @@ start-local-db: ## Run the local db as docker container
 .PHONY: test
 test: ## Run tests locally
 	$(TEST)
+
+.PHONY: security-check
+security-check: ## Run bandit security checker locally
+	$(BANDIT) --recursive --ini .bandit app
 
 .PHONY: help
 help: ## Display this help

--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,7 @@ mypy = "*"
 types-gevent = "*"
 django-stubs = "~=5.0.4"
 debugpy = "*"
+bandit = "*"
 
 [requires]
 python_version = "3.12"

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     HTTP_PORT = str(os.environ.get('HTTP_PORT', "8000"))
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
-        'bind': f"{'0.0.0.0'}:{HTTP_PORT}",
+        'bind': f"{'0.0.0.0'}:{HTTP_PORT}",  # nosec B104
         'worker_class': 'gevent',
         'workers': int(os.environ.get('GUNICORN_WORKERS',
                                       '2')),  # scaling horizontally is left to Kubernetes


### PR DESCRIPTION
I previously had good experience using [bandit](https://bandit.readthedocs.io) for security checks and would suggest to use it here as well (probably best in the pipeline).

What are your thoughts on this @boecklic @schtibe @asteiner-swisstopo @adk-swisstopo @ltshb @benschs (feel free to include more people to the discussion)

On a side note: There is no `RFC` label [as documented in the workflow](https://github.com/geoadmin/doc-guidelines/blob/master/GIT_FLOW.md#pr-for-request-for-comment-rfc)