### PR TITLE
PB-1026 Add settings for tests

### DIFF
--- a/app/config/settings_test.py
+++ b/app/config/settings_test.py
@@ -1,0 +1,3 @@
+from .settings_dev import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+TESTING = True


### PR DESCRIPTION
Introducing the BOD import command in service control requires setting a `TESTING` flag during tests. This is done by using a dedicated `test_settings.py`. To be able to run the tests in the feature branch, it is necessary to create this file and change the configuration previously.

This is related to https://github.com/geoadmin/infra-terraform-bgdi-builder/pull/300