### PR TITLE
PB-1109: Add PUT endpoint to update user

### DIFF
--- a/app/access/api.py
+++ b/app/access/api.py
@@ -125,8 +125,8 @@ def update_user(
 
     Return HTTP status code
     - 200 (OK) if the user has been updated successfully
-    - 404 (Not Found) if there is no user with the given username or if there is
-      no provider with the given ID
+    - 400 (Bad Request) if there is no provider with the given ID
+    - 404 (Not Found) if there is no user with the given username
     - 500 (Internal Server Error) if there is an inconsistency with Cognito
     - 503 (Service Unavailable) if Cognito cannot be reached
     """
@@ -136,7 +136,7 @@ def update_user(
             raise Http404()
 
         if not Provider.objects.filter(id=user_in.provider_id).exists():
-            raise HttpError(HTTPStatus.NOT_FOUND, "Provider does not exist")
+            raise HttpError(HTTPStatus.BAD_REQUEST, "Provider does not exist")
 
         for attr, value in user_in.dict(exclude_unset=True).items():
             setattr(user_object, attr, value)

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -118,8 +118,10 @@ def delete(request: HttpRequest, username: str) -> HttpResponse:
 
 
 @router.put("users/{username}")
-def update_user(request: HttpRequest, username: str, user_in: UserSchema) -> HttpResponse:
-    """Update the given user with the given user data.
+def update_user(
+    request: HttpRequest, username: str, user_in: UserSchema
+) -> HttpResponse | UserSchema:
+    """Update the given user with the given user data and return it.
 
     Return HTTP status code
     - 200 (OK) if the user has been updated successfully
@@ -143,4 +145,4 @@ def update_user(request: HttpRequest, username: str, user_in: UserSchema) -> Htt
         updated = update_cognito_user(user_object)
         if not updated:
             raise HttpError(HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")
-        return HttpResponse(status=HTTPStatus.OK)
+        return user_to_response(user_object)

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -123,9 +123,9 @@ def update_user(request: HttpRequest, username: str, user_in: UserSchema) -> Htt
 
     Return HTTP status code
     - 200 (OK) if the user has been updated successfully
-    - 404 (Not Found) if there is no user with the given username
+    - 404 (Not Found) if there is no user with the given username or if there is
+      no provider with the given ID
     - 500 (Internal Server Error) if there is an inconsistency with Cognito
-    - 500 (Internal Server Error) if there no provider with the given ID
     - 503 (Service Unavailable) if Cognito cannot be reached
     """
     with transaction.atomic():

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -134,7 +134,7 @@ def update_user(request: HttpRequest, username: str, user_in: UserSchema) -> Htt
             raise Http404()
 
         if not Provider.objects.filter(id=user_in.provider_id).exists():
-            raise HttpError(HTTPStatus.INTERNAL_SERVER_ERROR, "Provider does not exist")
+            raise HttpError(HTTPStatus.NOT_FOUND, "Provider does not exist")
 
         for attr, value in user_in.dict(exclude_unset=True).items():
             setattr(user_object, attr, value)

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -117,7 +117,7 @@ def delete(request: HttpRequest, username: str) -> HttpResponse:
         return HttpResponse(status=204)
 
 
-@router.put("users/{username}")
+@router.put("users/{username}", auth=PermissionAuth('access.change_user'))
 def update_user(
     request: HttpRequest, username: str, user_in: UserSchema
 ) -> HttpResponse | UserSchema:

--- a/app/access/api.py
+++ b/app/access/api.py
@@ -1,5 +1,8 @@
+from http import HTTPStatus
+
 from cognito.utils.user import create_cognito_user
 from cognito.utils.user import delete_cognito_user
+from cognito.utils.user import update_cognito_user
 from ninja import Router
 from ninja.errors import HttpError
 from provider.models import Provider
@@ -112,3 +115,32 @@ def delete(request: HttpRequest, username: str) -> HttpResponse:
             raise HttpError(500, "Internal Server Error")
         user_to_delete.delete()
         return HttpResponse(status=204)
+
+
+@router.put("users/{username}")
+def update_user(request: HttpRequest, username: str, user_in: UserSchema) -> HttpResponse:
+    """Update the given user with the given user data.
+
+    Return HTTP status code
+    - 200 (OK) if the user has been updated successfully
+    - 404 (Not Found) if there is no user with the given username
+    - 500 (Internal Server Error) if there is an inconsistency with Cognito
+    - 500 (Internal Server Error) if there no provider with the given ID
+    - 503 (Service Unavailable) if Cognito cannot be reached
+    """
+    with transaction.atomic():
+        user_object = User.objects.select_for_update().filter(username=username).first()
+        if not user_object:
+            raise Http404()
+
+        if not Provider.objects.filter(id=user_in.provider_id).exists():
+            raise HttpError(HTTPStatus.INTERNAL_SERVER_ERROR, "Provider does not exist")
+
+        for attr, value in user_in.dict(exclude_unset=True).items():
+            setattr(user_object, attr, value)
+        user_object.save()
+
+        updated = update_cognito_user(user_object)
+        if not updated:
+            raise HttpError(HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")
+        return HttpResponse(status=HTTPStatus.OK)

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -10,7 +10,6 @@ from utils.testing import create_user_with_permissions
 from django.test import TestCase
 
 
-# pylint: disable=too-many-public-methods
 class ApiTestCase(TestCase):
 
     def setUp(self):
@@ -39,6 +38,9 @@ class ApiTestCase(TestCase):
         )
 
         assert actual == expected
+
+
+class GetUserTestCase(ApiTestCase):
 
     def test_get_user_returns_existing_user(self):
         create_user_with_permissions('test', 'test', [('access', 'user', 'view_user')])
@@ -145,6 +147,9 @@ class ApiTestCase(TestCase):
 
         assert response.status_code == 403
         assert response.json() == {"code": 403, "description": "Forbidden"}
+
+
+class PostUserTestCase(ApiTestCase):
 
     @patch('access.api.create_cognito_user')
     def test_post_users_creates_new_user_in_db_and_returns_it(self, create_cognito_user):
@@ -333,6 +338,9 @@ class ApiTestCase(TestCase):
         assert not create_cognito_user.called
         assert User.objects.count() == 1
 
+
+class DeleteUserTestCase(ApiTestCase):
+
     @patch('access.api.delete_cognito_user')
     def test_delete_user_deletes_user(self, delete_cognito_user):
         delete_cognito_user.return_value = True
@@ -413,6 +421,9 @@ class ApiTestCase(TestCase):
         assert response.json() == {"code": 403, "description": "Forbidden"}
         assert User.objects.count() == 1
         assert not delete_cognito_user.called
+
+
+class UpdateUserTestCase(ApiTestCase):
 
     @patch('access.api.update_cognito_user')
     def test_update_user_updates_existing_user_as_expected(self, update_cognito_user):

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -465,7 +465,7 @@ class UpdateUserTestCase(ApiTestCase):
         user_after = User.objects.filter(username="dude").first()
         assert user_after == user_before
 
-    def test_update_user_returns_404_and_leaves_user_as_is_if_provider_nonexistent(self):
+    def test_update_user_returns_400_and_leaves_user_as_is_if_provider_nonexistent(self):
 
         user_before = User.objects.filter(username="dude").first()
         nonexistent_id = Provider.objects.last().id + 1234
@@ -479,8 +479,8 @@ class UpdateUserTestCase(ApiTestCase):
 
         response = self.client.put("users/dude", json=payload)
 
-        assert response.status_code == 404
-        assert response.data == {"code": 404, "description": "Provider does not exist"}
+        assert response.status_code == 400
+        assert response.data == {"code": 400, "description": "Provider does not exist"}
         user_after = User.objects.filter(username="dude").first()
         assert user_after == user_before
 

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -454,7 +454,7 @@ class ApiTestCase(TestCase):
         user_after = User.objects.filter(username="dude").first()
         assert user_after == user_before
 
-    def test_update_user_returns_500_and_leaves_user_as_is_if_provider_nonexistent(self):
+    def test_update_user_returns_404_and_leaves_user_as_is_if_provider_nonexistent(self):
 
         user_before = User.objects.filter(username="dude").first()
         nonexistent_id = Provider.objects.last().id + 1234
@@ -468,8 +468,8 @@ class ApiTestCase(TestCase):
 
         response = self.client.put("users/dude", json=payload)
 
-        assert response.status_code == 500
-        assert response.data == {"code": 500, "description": "Provider does not exist"}
+        assert response.status_code == 404
+        assert response.data == {"code": 404, "description": "Provider does not exist"}
         user_after = User.objects.filter(username="dude").first()
         assert user_after == user_before
 

--- a/app/access/tests/test_api.py
+++ b/app/access/tests/test_api.py
@@ -429,7 +429,7 @@ class ApiTestCase(TestCase):
         response = self.client.put("users/dude", json=payload)
 
         assert response.status_code == 200
-        assert response.content == b''
+        assert response.data == payload
         user = User.objects.filter(username="dude").first()
         for key, value in payload.items():
             assert getattr(user, key) == value

--- a/app/cognito/tests/test_user_utils.py
+++ b/app/cognito/tests/test_user_utils.py
@@ -19,7 +19,7 @@ class ClientTestCase(TestCase):
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_create_user_creates_user(self, logger, client):
+    def test_create_cognito_user_creates_user(self, logger, client):
         client.return_value.create_user.return_value = True
 
         created = create_cognito_user(DummyUser('123', 'test@example.org'))
@@ -29,7 +29,7 @@ class ClientTestCase(TestCase):
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_create_user_does_not_create_existing_user(self, logger, client):
+    def test_create_cognito_user_does_not_create_existing_user(self, logger, client):
         client.return_value.create_user.return_value = False
 
         created = create_cognito_user(DummyUser('123', 'test@example.org'))
@@ -41,7 +41,7 @@ class ClientTestCase(TestCase):
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_delete_user_deletes_user(self, logger, client):
+    def test_delete_cognito_user_deletes_user(self, logger, client):
         client.return_value.delete_user.return_value = True
 
         deleted = delete_cognito_user(DummyUser('123', 'test@example.org'))
@@ -51,7 +51,7 @@ class ClientTestCase(TestCase):
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_delete_user_does_not_delete_nonexisting_user(self, logger, client):
+    def test_delete_cognito_user_does_not_delete_nonexisting_user(self, logger, client):
         client.return_value.delete_user.return_value = False
 
         deleted = delete_cognito_user(DummyUser('123', 'test@example.org'))

--- a/app/cognito/tests/test_user_utils.py
+++ b/app/cognito/tests/test_user_utils.py
@@ -79,4 +79,6 @@ class ClientTestCase(TestCase):
         updated = update_cognito_user(DummyUser('123', 'test@example.org'))
 
         self.assertEqual(updated, False)
-        self.assertIn(call.warning('User %s does not exist, not updated', '123'), logger.mock_calls)
+        self.assertIn(
+            call.critical('User %s does not exist, not updated', '123'), logger.mock_calls
+        )

--- a/app/cognito/tests/test_user_utils.py
+++ b/app/cognito/tests/test_user_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from cognito.utils.user import create_cognito_user
 from cognito.utils.user import delete_cognito_user
-from cognito.utils.user import update_user
+from cognito.utils.user import update_cognito_user
 
 from django.test import TestCase
 
@@ -63,20 +63,20 @@ class ClientTestCase(TestCase):
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_update_user_updates_user(self, logger, client):
+    def test_update_cognito_user_updates_user(self, logger, client):
         client.return_value.update_user.return_value = True
 
-        updated = update_user(DummyUser('123', 'test@example.org'))
+        updated = update_cognito_user(DummyUser('123', 'test@example.org'))
 
         self.assertEqual(updated, True)
         self.assertIn(call.info('User %s updated', '123'), logger.mock_calls)
 
     @patch('cognito.utils.user.Client')
     @patch('cognito.utils.user.logger')
-    def test_update_user_does_not_update_nonexisting_user(self, logger, client):
+    def test_update_cognito_user_does_not_update_nonexisting_user(self, logger, client):
         client.return_value.update_user.return_value = False
 
-        updated = update_user(DummyUser('123', 'test@example.org'))
+        updated = update_cognito_user(DummyUser('123', 'test@example.org'))
 
         self.assertEqual(updated, False)
         self.assertIn(call.warning('User %s does not exist, not updated', '123'), logger.mock_calls)

--- a/app/cognito/utils/user.py
+++ b/app/cognito/utils/user.py
@@ -37,7 +37,7 @@ def delete_cognito_user(user: User) -> bool:
     return deleted
 
 
-def update_user(user: User) -> bool:
+def update_cognito_user(user: User) -> bool:
     """ Update the given user in cognito.
 
     Returns True, if the user has been updated.

--- a/app/cognito/utils/user.py
+++ b/app/cognito/utils/user.py
@@ -48,5 +48,5 @@ def update_cognito_user(user: User) -> bool:
     if updated:
         logger.info("User %s updated", user.username)
     else:
-        logger.warning("User %s does not exist, not updated", user.username)
+        logger.critical("User %s does not exist, not updated", user.username)
     return updated


### PR DESCRIPTION
Adds PUT endpoint `users/{username}` to the the REST API of service-control that allows you to update a user.

Summary of changes:

1. Add new PUT endpoint `users/{username}` that returns HTTP status code
    - 200 (OK) if the user has been updated successfully
    - 404 (Not Found) if there is no user with the given username
    - 500 (Internal Server Error) if there is an inconsistency with Cognito or if there is no provider with the given ID
    :warning: This is is the only difference in behaviour to the DELETE in #34
    - 503 (Service Unavailable) if Cognito cannot be reached

    :information_source: This uses PUT and not PATCH because we deem it good enough to start with and it's supposedly easier to implement. It's a bit annoying maybe that the user has to specify all fields, even those she/he does not want to change. But then again they can those values via the GET.

2. Rename `cognito.utils.user.update_user` to `update_cognito_user` to put more clearly indicate that this is about Cognito and not about the User model in Django. See the discussion in #34.

Example payload to PUT `users/{username}`:

```json
{
    "username": "dude",
    "first_name": "Jeff",
    "last_name": "Bridges",
    "email": "tron@hollywood.com",
    "provider_id": 123,
}
```

Example response if provider does not exist:

```json
{
    "code": 500,
    "description": "Provider does not exist"
}
```