### PR TITLE
Improve the usability of the admin UI

### DIFF
--- a/app/access/admin.py
+++ b/app/access/admin.py
@@ -8,8 +8,9 @@ from .models import User
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):  # type:ignore[type-arg]
     '''Admin View for User'''
-    list_display = ('provider', 'username', 'deleted_at')
-    actions = ["disable"]
+    list_display = ('username', 'deleted_at', 'provider')
+    list_filter = ('deleted_at', ('provider', admin.RelatedOnlyFieldListFilter))
+    actions = ('disable',)
 
     @admin.action(description="Disable selected users")
     def disable(self, request: HttpRequest, queryset: models.QuerySet[User]) -> None:

--- a/app/distributions/admin.py
+++ b/app/distributions/admin.py
@@ -8,7 +8,13 @@ from .models import Dataset
 class AttributionAdmin(admin.ModelAdmin):  # type:ignore[type-arg]
     '''Admin View for Attribution'''
 
+    list_display = ('name_en', 'provider')
+    list_filter = (('provider', admin.RelatedOnlyFieldListFilter),)
+
 
 @admin.register(Dataset)
 class DatasetAdmin(admin.ModelAdmin):  # type:ignore[type-arg]
     '''Admin View for Dataset'''
+
+    list_display = ('slug', 'provider')
+    list_filter = (('provider', admin.RelatedOnlyFieldListFilter),)

--- a/app/provider/admin.py
+++ b/app/provider/admin.py
@@ -6,3 +6,5 @@ from .models import Provider
 @admin.register(Provider)
 class ProviderAdmin(admin.ModelAdmin):  # type:ignore[type-arg]
     '''Admin View for Provider'''
+
+    list_display = ('acronym_en', 'name_en')

--- a/app/provider/models.py
+++ b/app/provider/models.py
@@ -7,7 +7,7 @@ class Provider(models.Model):
     _context = "Provider model"
 
     def __str__(self) -> str:
-        return str(self.name_en)
+        return str(self.acronym_en)
 
     '''
     Note: The "blank=False" for a model field doesn't prevent DB changes.


### PR DESCRIPTION
Improve the usability of the admin UI by by adding filters and optimize displayed rows.

Providers:
- Use the acronym rather than the name in `__str__` so that provider filters are displayed more clearly
- Show `acronym_en` and `name_en` rather than only `name_en`

![image](https://github.com/user-attachments/assets/fd536739-d9d1-4254-83db-1fa7776ae49d)

Users:
- Move `provider` to the back (previously one needed to click on the provider to edit the user)
- Add filters for `deleted_at` and `provider`

![image](https://github.com/user-attachments/assets/5e205a42-48af-40e7-9697-68217ea5681e)

Attribution:
- Show `name_en` and `provider` rather than only `name_en`
- Add filter for `provider`

![image](https://github.com/user-attachments/assets/0fbf5dee-79ff-4870-bafa-3a90706368c8)

Dataset:
- Show `slug` and `provider` rather than only `slug`
- Add filter for `provider`

![image](https://github.com/user-attachments/assets/7210f04d-f660-4ab7-96ec-a51ff0ed5af4)

