### PR TITLE
Fix some bugs in the user admin UI and model

### DIFF
--- a/app/access/admin.py
+++ b/app/access/admin.py
@@ -9,20 +9,22 @@ from .models import User
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):  # type:ignore[type-arg]
     '''Admin View for User'''
+
     list_display = ('user_id', 'username', 'deleted_at', 'provider')
     list_filter = ('deleted_at', ('provider', admin.RelatedOnlyFieldListFilter))
     actions = ('disable',)
 
     @admin.action(description="Disable selected users")
     def disable(self, request: HttpRequest, queryset: models.QuerySet[User]) -> None:
-        for u in queryset:
-            u.disable()
+        for user in queryset:
+            user.disable()
 
     def get_queryset(self, request: HttpRequest) -> models.QuerySet[User]:
         return User.all_objects.get_queryset()
 
+    def delete_queryset(self, request: HttpRequest, queryset: models.QuerySet[User]) -> None:
+        for user in queryset:
+            user.delete()
+
     def get_readonly_fields(self, request: HttpRequest, obj: Model | None = None) -> list[str]:
-        # Make user_id readonly when editing, but not when creating
-        if obj:
-            return ['user_id']
-        return []
+        return ['user_id', 'deleted_at']


### PR DESCRIPTION
This pull request addresses issues in the user model and admin UI related to Cognito.

User Model
- Add additional documentation and hints.
- Use `select_for_update` with `all_objects` to enable updates and deletions of disabled users.

Admin UI
- Avoid using the query set to delete users, as it bypasses Cognito.
- Make `delete_at` read-only, as directly updating this attribute does not enable or disable users in Cognito.
- Make `user_id` read-only, as the field currently has no validation and would otherwise allow creating users with invalid IDs.