### PR TITLE
PB-1288 Set e-mail as validated in cognito

### DIFF
--- a/app/tests/cognito/test_cognito_client.py
+++ b/app/tests/cognito/test_cognito_client.py
@@ -105,6 +105,8 @@ def test_create_user_creates_managed(boto3, cognito_user_response_factory):
         UserAttributes=[{
             'Name': 'email', 'Value': 'test@example.org'
         }, {
+            'Name': 'email_verified', 'Value': 'true'
+        }, {
             'Name': 'preferred_username', 'Value': '1234'
         }, {
             'Name': client.managed_flag_name, 'Value': 'true'
@@ -172,18 +174,37 @@ def test_update_user_updates_managed(boto3, cognito_user_response_factory):
     )
 
     client = Client()
-    updated = client.update_user('2ihg2ox304po', '1234', 'test@example.org')
+    updated = client.update_user('2ihg2ox304po', '5678', 'new@example.org')
     assert updated is True
     assert '().admin_update_user_attributes' in [call[0] for call in boto3.mock_calls]
+    assert '().admin_reset_user_password' in [call[0] for call in boto3.mock_calls]
     assert call().admin_update_user_attributes(
         UserPoolId=client.user_pool_id,
         Username='2ihg2ox304po',
         UserAttributes=[{
-            'Name': 'email', 'Value': 'test@example.org'
+            'Name': 'email', 'Value': 'new@example.org'
         }, {
-            'Name': 'preferred_username', 'Value': '1234'
+            'Name': 'email_verified', 'Value': 'true'
+        }, {
+            'Name': 'preferred_username', 'Value': '5678'
         }]
     ) in boto3.mock_calls
+    assert call().admin_reset_user_password(
+        UserPoolId=client.user_pool_id, Username='2ihg2ox304po'
+    ) in boto3.mock_calls
+
+
+@patch('cognito.utils.client.client')
+def test_update_user_does_not_update_unchanged_managed(boto3, cognito_user_response_factory):
+    boto3.return_value.admin_get_user.return_value = cognito_user_response_factory(
+        '2ihg2ox304po', '1234', managed=True, attributes_key='UserAttributes'
+    )
+
+    client = Client()
+    updated = client.update_user('2ihg2ox304po', '1234', 'test@example.org')
+    assert updated is True
+    assert '().admin_update_user_attributes' not in [call[0] for call in boto3.mock_calls]
+    assert '().admin_reset_user_password' not in [call[0] for call in boto3.mock_calls]
 
 
 @patch('cognito.utils.client.client')


### PR DESCRIPTION
This PR marks the email of a user in Cognito as validated.

This allows login with email and password reset functionality until we implement a better solution for general availability.

With this change, users will either have a valid email and be able to log in, or have an invalid email and be unable to log in. In both cases however, the email will be marked as validated in Cognito.

The actual validation of the email is handled indirectly:
- Upon user creation, the user receives an email with a temporary password.
-  If the email is changed, the user must go through a password restoration process.

If the email is invalid, the user will be unable to log in.