### PR TITLE
Set the manage.py to default to the general settings file

### DIFF
--- a/app/config/asgi.py
+++ b/app/config/asgi.py
@@ -11,6 +11,7 @@ import os
 
 from django.core.asgi import get_asgi_application
 
+# default to the setting that's being created in DOCKERFILE
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
 
 application = get_asgi_application()

--- a/app/manage.py
+++ b/app/manage.py
@@ -7,7 +7,7 @@ import sys
 def main() -> None:
     """Run administrative tasks."""
     # default to the prod settings. Can be overwritten with .env
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings_prod')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
     try:
         from django.core.management import \
             execute_from_command_line  # pylint: disable=import-outside-toplevel

--- a/app/manage.py
+++ b/app/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main() -> None:
     """Run administrative tasks."""
-    # default to the prod settings. Can be overwritten with .env
+    # default to the setting that's being created in DOCKERFILE
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
     try:
         from django.core.management import \

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -37,6 +37,7 @@ from django.core.wsgi import get_wsgi_application
 # Here we cannot uses `from django.conf import settings` because it breaks the `make gunicornserver`
 from config.settings_prod import get_logging_config
 
+# default to the setting that's being created in DOCKERFILE
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 application = get_wsgi_application()
 


### PR DESCRIPTION
This referenced settings file is copied when building the docker image


- [ ] Model changes documented in the [business entity model](https://ltwiki.adr.admin.ch:8443/display/PB/Business+Entity+Model)
