### PR TITLE
PB-1580 Update link to point to Atlassian cloud

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 
-- [ ] Model changes documented in the [business entity model](https://ltwiki.adr.admin.ch:8443/display/PB/Business+Entity+Model)
+- [ ] Model changes documented in the [business entity model](https://swissgeoplatform.atlassian.net/wiki/spaces/PB/pages/16155637/Business+Entity+Model)


### PR DESCRIPTION
Link before:
https://ltwiki.adr.admin.ch:8443/display/PB/Business+Entity+Model

Link now: 
https://swissgeoplatform.atlassian.net/wiki/spaces/PB/pages/16155637/Business+Entity+Model

I thought about using a permalink (via the "Share" button on the top right: https://swissgeoplatform.atlassian.net/wiki/x/9YP2). But on the new Confluence, it keeps a history of the URLs of a page and automatically redirects you in case that the page was moved. So I figured we could keep the nice-to-read version.