### PR TITLE
Set default local log level to INFO

### DIFF
--- a/app/config/logging-cfg-local.yaml
+++ b/app/config/logging-cfg-local.yaml
@@ -4,7 +4,7 @@ disable_existing_loggers: False
 root:
   handlers:
     - console
-  level: DEBUG
+  level: INFO
   propagate: True
 
 # configure loggers per app


### PR DESCRIPTION
Sets the default log level to `INFO` when working locally, `DEBUG` is too noisy.