### PR TITLE
PB-1510: Update bod image to postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         node /app/start.js;
       "
   bod:
-    image: postgis/postgis:13-3.4
+    image: postgis/postgis:16-3.5
     environment:
       - POSTGRES_USER=${BOD_USER}
       - POSTGRES_PASSWORD=${BOD_PW}


### PR DESCRIPTION
Django 5.2 requires at least [Postgres 14](https://docs.djangoproject.com/en/5.2/ref/databases/#postgresql-notes), BOD uses Postgres 16 as far as I know (right?)