### PR TITLE
B-1805: Fixed logout for un-authorized user

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -2,7 +2,6 @@ import logging
 import urllib
 
 from django.conf import settings
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import logout
 from django.http import HttpRequest
 from django.http import HttpResponse
@@ -18,7 +17,7 @@ def oauth2_proxy_base_url(request: HttpRequest) -> str:
     return request.build_absolute_uri('/')
 
 
-def custom_admin_login(request: HttpRequest) -> HttpResponse:
+def admin_oauth2_proxy_login(request: HttpRequest) -> HttpResponse:
     # Redirect URL after successful login
     redirect_uri = f"{request.build_absolute_uri(reverse('admin:index'))}"
 
@@ -29,8 +28,7 @@ def custom_admin_login(request: HttpRequest) -> HttpResponse:
     return redirect(oauth2_proxy_login_url)
 
 
-@staff_member_required
-def custom_admin_logout(request: HttpRequest) -> HttpResponse:
+def admin_oauth2_proxy_logout(request: HttpRequest) -> HttpResponse:
     # logout the user from Django
     logout(request)
 

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -28,14 +28,14 @@ if settings.ENABLE_OAUTH2_PROXY:
     customAdminUrls = [
         path(
             settings.API_PATH_PREFIX + 'admin/logout/',
-            views.custom_admin_logout,
-            name='custom_admin_logout'
+            views.admin_oauth2_proxy_logout,
+            name='admin_oauth2_proxy_logout'
         ),
         # Add a new login endpoint for oauth2 login
         path(
             settings.API_PATH_PREFIX + 'admin/oauth2/login/',
-            views.custom_admin_login,
-            name='custom_admin_login'
+            views.admin_oauth2_proxy_login,
+            name='admin_oauth2_proxy_login'
         ),
     ]
 

--- a/app/templates/admin/login.html
+++ b/app/templates/admin/login.html
@@ -46,10 +46,24 @@
 
 <form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
   <div class="submit-row">
-    <!-- OAuth2 Login Button -->
-    <a href="{% url 'custom_admin_login' %}" class="button" style="margin-left: 10px; padding: 10px 15px;">
-    Login via PP-BGDI OAuth2
-    </a>
+    {% if user.is_authenticated %}
+      <!-- User authenticated but without the staff member access are redirected by django to this page.
+           Therefore we show the logout button so the user can logout and login with another account.
+      -->
+      <!-- LOGOUT -->
+      <a href="{% url 'admin_oauth2_proxy_logout' %}" class="button" style="margin-left: 10px; padding: 10px 15px;">
+        Logout
+      </a>
+    {% else %}
+      <!-- This should not happened because the /admin/login page is protected by oauth2-proxy and this one Would
+           redirect to the managed login page if the user is not authenticated. This page is only shown for
+           authenticated without admin interface access.
+      -->
+      <!-- OAuth2 Login Button -->
+      <a href="{% url 'admin_oauth2_proxy_login' %}" class="button" style="margin-left: 10px; padding: 10px 15px;">
+        Login via PP-BGDI OAuth2
+      </a>
+    {% endif %}
   </div>
 </form>
 


### PR DESCRIPTION
Some user might have successfully authenticate but are not authorized to access
the admin interface. Those needs to be able to logout. That's why the `@staff_member_required`
is removed from the `custom_admin_logout` endpoint and that a logout button
is added to the login page.

Also don't breaks the oauth2-proxy middleware when some infos are missing.
See also https://github.com/geoadmin/infra-kubernetes/pull/918


- [ ] Model changes documented in the [business entity model](https://swissgeoplatform.atlassian.net/wiki/spaces/PB/pages/16155637/Business+Entity+Model)
